### PR TITLE
Add geolocator module

### DIFF
--- a/assets/js/geolocator.js
+++ b/assets/js/geolocator.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var Geolocator = (function() {
+  function getLocation() {
+    return new Promise(function(resolve, reject) {
+      navigator.geolocation.getCurrentPosition(
+        function(position) {
+          resolve([position.coords.latitude, position.coords.longitude]);
+        },
+        function(error) {
+          reject(error);
+        }
+      );
+    });
+  }
+
+  return {
+    getUserLocation: getLocation
+  };
+})();


### PR DESCRIPTION
Adds a simple module that can be used to retrieve the user's geolocation. It returns a Promise to facilitate chaining and error catching. If you're not familiar with JavaScript Promises, check out [this blog post](https://davidwalsh.name/promises).

We **DO NOT** have to use Promises if the group does not want to. This module can be rewritten to allow callback functions to be passed in instead. If this is a preferred approach, let me know and I will modify the code.