### PR TITLE
Add ticketmaster api wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/*
 .babelrc
 package.json
 .eslintrc.json
+tests/
+tests/*
+webpack.config.js

--- a/assets/js/ticketmaster.js
+++ b/assets/js/ticketmaster.js
@@ -8,7 +8,7 @@ var TicketMaster = (function() {
     for (var n in params) {
       if (params.hasOwnProperty(n)) {
         if (typeof params[n] === 'string') {
-          params[n] = params[n].replace(/ /g, '%20');
+          params[n] = params[n].replace(/ /g, '+');
         }
         rootUrl += `&${n}=${params[n]}`;
       }
@@ -40,13 +40,44 @@ var TicketMaster = (function() {
   }
 
   // Artist search
+  function artistSearch(params) {
+    return new Promise((resolve, reject) => {
+      let rootUrl = 'https://app.ticketmaster.com/discovery/v2/attractions.json?';
+      let url = buildUrl(rootUrl, params);
+      $.ajax({
+        type: 'GET',
+        url: url,
+        async: true,
+        dataType: 'json',
+        success: function(json) {
+          resolve(json);
+        },
+        error: function(xhr, status, err) {
+          reject(err);
+        }
+      });
+    });
+  }
   return {
-    eventSearch: eventSearch
+    eventSearch: eventSearch,
+    artistSearch: artistSearch
   };
 })();
 
-TicketMaster.eventSearch({
-  keyword: 'kings of leon',
+// TicketMaster.eventSearch({
+//   keyword: 'kings of leon',
+//   size: 5
+// })
+//   .then(function(json) {
+//     console.log(json);
+//   })
+//   .catch(function(err) {
+//     console.log(err);
+//   });
+
+console.log('Searching for artist...');
+TicketMaster.artistSearch({
+  keyword: 'Group love',
   size: 5
 })
   .then(function(json) {

--- a/assets/js/ticketmaster.js
+++ b/assets/js/ticketmaster.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var TicketMaster = (function() {
+  let apiKey = '8XlOGLUKhcwBVxoH5g39eY2mBvyz8iAm';
+
+  // Build URL
+  function buildUrl(rootUrl, params) {
+    for (var n in params) {
+      if (params.hasOwnProperty(n)) {
+        if (typeof params[n] === 'string') {
+          params[n] = params[n].replace(/ /g, '%20');
+        }
+        rootUrl += `&${n}=${params[n]}`;
+      }
+    }
+
+    rootUrl += `&apikey=${apiKey}`;
+    return rootUrl;
+  }
+
+  // Event search
+  function eventSearch(params) {
+    return new Promise((resolve, reject) => {
+      let rootUrl = 'https://app.ticketmaster.com/discovery/v2/events.json?';
+      let url = buildUrl(rootUrl, params);
+      console.log(url);
+      $.ajax({
+        type: 'GET',
+        url: url,
+        async: true,
+        dataType: 'json',
+        success: function(json) {
+          resolve(json);
+        },
+        error: function(xhr, status, err) {
+          reject(err);
+        }
+      });
+    });
+  }
+
+  // Artist search
+  return {
+    eventSearch: eventSearch
+  };
+})();
+
+TicketMaster.eventSearch({
+  keyword: 'kings of leon',
+  size: 5
+})
+  .then(function(json) {
+    console.log(json);
+  })
+  .catch(function(err) {
+    console.log(err);
+  });

--- a/assets/js/ticketmaster.js
+++ b/assets/js/ticketmaster.js
@@ -39,8 +39,8 @@ var TicketMaster = (function() {
     });
   }
 
-  // Artist search
-  function artistSearch(params) {
+  // Attraction search
+  function attractionSearch(params) {
     return new Promise((resolve, reject) => {
       let rootUrl = 'https://app.ticketmaster.com/discovery/v2/attractions.json?';
       let url = buildUrl(rootUrl, params);
@@ -58,13 +58,41 @@ var TicketMaster = (function() {
       });
     });
   }
+
+  // Venue search
+  function venueSearch(params) {
+    return new Promise((resolve, reject) => {
+      let rootUrl = 'https://app.ticketmaster.com/discovery/v2/venues.json?';
+      let url = buildUrl(rootUrl, params);
+      $.ajax({
+        type: 'GET',
+        url: url,
+        async: true,
+        dataType: 'json',
+        success: function(json) {
+          resolve(json);
+        },
+        error: function(xhr, status, err) {
+          reject(err);
+        }
+      });
+    });
+  }
+
   return {
     eventSearch: eventSearch,
-    artistSearch: artistSearch
+    attractionSearch: attractionSearch,
+    venueSearch: venueSearch
   };
 })();
 
+/*
+Example searches below. Refer to the ticketmaster docs for all of the parameter options
+*/
+
+// console.log('Searching for Kings Of Leon events at Philips Arena');
 // TicketMaster.eventSearch({
+//   id: 'KovZpa2Xke',
 //   keyword: 'kings of leon',
 //   size: 5
 // })
@@ -75,14 +103,25 @@ var TicketMaster = (function() {
 //     console.log(err);
 //   });
 
-console.log('Searching for artist...');
-TicketMaster.artistSearch({
-  keyword: 'Group love',
-  size: 5
-})
-  .then(function(json) {
-    console.log(json);
-  })
-  .catch(function(err) {
-    console.log(err);
-  });
+// console.log('Searching for artist...');
+// TicketMaster.artistSearch({
+//   keyword: 'Group love',
+//   size: 5
+// })
+//   .then(function(json) {
+//     console.log(json);
+//   })
+//   .catch(function(err) {
+//     console.log(err);
+//   });
+
+// console.log('Searching for venue..');
+// TicketMaster.venueSearch({
+//   keyword: 'Philips Arena'
+// })
+//   .then(function(json) {
+//     console.log(json);
+//   })
+//   .catch(function(err) {
+//     console.log(err);
+//   });

--- a/data/example_of_empty_result_set.json
+++ b/data/example_of_empty_result_set.json
@@ -1,0 +1,17 @@
+// This is an example of what is returned when there are no results
+// I searched for Kings of Leon at Philips Areana
+// I think the key attribute here is the totalElements part of 'page'. We should check that first to determine
+// if there are results to show.
+{
+  "_links": {
+    "self": {
+      "href": "/discovery/v2/events.json?size=5&id=KovZpa2Xke&keyword=kings+of+leon"
+    }
+  },
+  "page": {
+    "size": 5,
+    "totalElements": 0,
+    "totalPages": 0,
+    "number": 0
+  }
+}

--- a/data/keyword_attraction_search.json
+++ b/data/keyword_attraction_search.json
@@ -1,0 +1,399 @@
+// Response data from attraction search for keywords 'Group' and 'love'
+// the 'id' variable is key here. If the user wants to then do an event search for that specific attraction, 
+// we need to pass that id as a parameter to the event search
+{
+  "_embedded": {
+    "attractions": [
+      {
+        "name": "Grouplove",
+        "type": "attraction",
+        "id": "K8vZ917ufxV",
+        "test": false,
+        "url": "http://www.ticketmaster.com/artist/1504793",
+        "locale": "en-us",
+        "externalLinks": {
+          "youtube": [
+            {
+              "url": "https://www.youtube.com/user/grouplovemusic"
+            }
+          ],
+          "twitter": [
+            {
+              "url": "https://twitter.com/GROUPLOVE"
+            }
+          ],
+          "lastfm": [
+            {
+              "url": "http://www.last.fm/music/Grouplove"
+            }
+          ],
+          "facebook": [
+            {
+              "url": "https://www.facebook.com/GROUPLOVE"
+            }
+          ],
+          "wiki": [
+            {
+              "url": "https://en.wikipedia.org/wiki/Grouplove"
+            }
+          ],
+          "musicbrainz": [
+            {
+              "id": "d8e41375-bd8d-4e39-9da7-f0c171e97086"
+            }
+          ],
+          "homepage": [
+            {
+              "url": "http://www.grouplovemusic.com/"
+            }
+          ]
+        },
+        "images": [
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_TABLET_LANDSCAPE_3_2.jpg",
+            "width": 1024,
+            "height": 683,
+            "fallback": false
+          },
+          {
+            "ratio": "4_3",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_CUSTOM.jpg",
+            "width": 305,
+            "height": 225,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_RECOMENDATION_16_9.jpg",
+            "width": 100,
+            "height": 56,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_RETINA_LANDSCAPE_16_9.jpg",
+            "width": 1136,
+            "height": 639,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_TABLET_LANDSCAPE_LARGE_16_9.jpg",
+            "width": 2048,
+            "height": 1152,
+            "fallback": false
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_RETINA_PORTRAIT_3_2.jpg",
+            "width": 640,
+            "height": 427,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_EVENT_DETAIL_PAGE_16_9.jpg",
+            "width": 205,
+            "height": 115,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_TABLET_LANDSCAPE_16_9.jpg",
+            "width": 1024,
+            "height": 576,
+            "fallback": false
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_ARTIST_PAGE_3_2.jpg",
+            "width": 305,
+            "height": 203,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/d37/55b49438-2338-4de1-846e-3a0c6e904d37_103381_RETINA_PORTRAIT_16_9.jpg",
+            "width": 640,
+            "height": 360,
+            "fallback": false
+          }
+        ],
+        "classifications": [
+          {
+            "primary": true,
+            "segment": {
+              "id": "KZFzniwnSyZfZ7v7nJ",
+              "name": "Music"
+            },
+            "genre": {
+              "id": "KnvZfZ7vAeA",
+              "name": "Rock"
+            },
+            "subGenre": {
+              "id": "KZazBEonSMnZfZ7v6dt",
+              "name": "Alternative Rock"
+            },
+            "type": {
+              "id": "KZAyXgnZfZ7v7nI",
+              "name": "Undefined"
+            },
+            "subType": {
+              "id": "KZFzBErXgnZfZ7v7lJ",
+              "name": "Undefined"
+            }
+          }
+        ],
+        "upcomingEvents": {
+          "_total": 38,
+          "tmr": 1,
+          "ticketmaster": 36,
+          "mfx-uk": 1
+        },
+        "_links": {
+          "self": {
+            "href": "/discovery/v2/attractions/K8vZ917ufxV?locale=en-us"
+          }
+        }
+      },
+      {
+        "name": "Grouplove and Portugal. the Man",
+        "type": "attraction",
+        "id": "K8vZ9173I57",
+        "test": false,
+        "url": "http://www.ticketmaster.com/artist/2012344",
+        "locale": "en-us",
+        "images": [
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dbimages/178227a.jpg",
+            "width": 205,
+            "height": 115,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_RECOMENDATION_16_9.jpg",
+            "width": 100,
+            "height": 56,
+            "fallback": true
+          },
+          {
+            "ratio": "4_3",
+            "url": "https://s1.ticketm.net/dbimages/178226a.jpg",
+            "width": 305,
+            "height": 225,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_RETINA_PORTRAIT_16_9.jpg",
+            "width": 640,
+            "height": 360,
+            "fallback": true
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_TABLET_LANDSCAPE_LARGE_16_9.jpg",
+            "width": 2048,
+            "height": 1152,
+            "fallback": true
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_RETINA_PORTRAIT_3_2.jpg",
+            "width": 640,
+            "height": 427,
+            "fallback": true
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_RETINA_LANDSCAPE_16_9.jpg",
+            "width": 1136,
+            "height": 639,
+            "fallback": true
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_TABLET_LANDSCAPE_16_9.jpg",
+            "width": 1024,
+            "height": 576,
+            "fallback": true
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_TABLET_LANDSCAPE_3_2.jpg",
+            "width": 1024,
+            "height": 683,
+            "fallback": true
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_ARTIST_PAGE_3_2.jpg",
+            "width": 305,
+            "height": 203,
+            "fallback": true
+          }
+        ],
+        "classifications": [
+          {
+            "primary": true,
+            "segment": {
+              "id": "KZFzniwnSyZfZ7v7nJ",
+              "name": "Music"
+            },
+            "genre": {
+              "id": "KnvZfZ7vAeA",
+              "name": "Rock"
+            },
+            "subGenre": {
+              "id": "KZazBEonSMnZfZ7v6dt",
+              "name": "Alternative Rock"
+            },
+            "type": {
+              "id": "KZAyXgnZfZ7v7nI",
+              "name": "Undefined"
+            },
+            "subType": {
+              "id": "KZFzBErXgnZfZ7v7lJ",
+              "name": "Undefined"
+            }
+          }
+        ],
+        "upcomingEvents": {
+          "_total": 0
+        },
+        "_links": {
+          "self": {
+            "href": "/discovery/v2/attractions/K8vZ9173I57?locale=en-us"
+          }
+        }
+      },
+      {
+        "name": "Portugal. the Man and Grouplove",
+        "type": "attraction",
+        "id": "K8vZ9173I5f",
+        "test": false,
+        "url": "http://www.ticketmaster.com/artist/2012345",
+        "locale": "en-us",
+        "images": [
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_RECOMENDATION_16_9.jpg",
+            "width": 100,
+            "height": 56,
+            "fallback": true
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_RETINA_PORTRAIT_16_9.jpg",
+            "width": 640,
+            "height": 360,
+            "fallback": true
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_TABLET_LANDSCAPE_LARGE_16_9.jpg",
+            "width": 2048,
+            "height": 1152,
+            "fallback": true
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_RETINA_PORTRAIT_3_2.jpg",
+            "width": 640,
+            "height": 427,
+            "fallback": true
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_RETINA_LANDSCAPE_16_9.jpg",
+            "width": 1136,
+            "height": 639,
+            "fallback": true
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_TABLET_LANDSCAPE_16_9.jpg",
+            "width": 1024,
+            "height": 576,
+            "fallback": true
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_TABLET_LANDSCAPE_3_2.jpg",
+            "width": 1024,
+            "height": 683,
+            "fallback": true
+          },
+          {
+            "ratio": "4_3",
+            "url": "https://s1.ticketm.net/dbimages/178223a.jpg",
+            "width": 305,
+            "height": 225,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dbimages/178224a.jpg",
+            "width": 205,
+            "height": 115,
+            "fallback": false
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/c/fbc/b293c0ad-c904-4215-bc59-8d7f2414dfbc_106141_ARTIST_PAGE_3_2.jpg",
+            "width": 305,
+            "height": 203,
+            "fallback": true
+          }
+        ],
+        "classifications": [
+          {
+            "primary": true,
+            "segment": {
+              "id": "KZFzniwnSyZfZ7v7nJ",
+              "name": "Music"
+            },
+            "genre": {
+              "id": "KnvZfZ7vAeA",
+              "name": "Rock"
+            },
+            "subGenre": {
+              "id": "KZazBEonSMnZfZ7v6dt",
+              "name": "Alternative Rock"
+            },
+            "type": {
+              "id": "KZAyXgnZfZ7v7nI",
+              "name": "Undefined"
+            },
+            "subType": {
+              "id": "KZFzBErXgnZfZ7v7lJ",
+              "name": "Undefined"
+            }
+          }
+        ],
+        "upcomingEvents": {
+          "_total": 0
+        },
+        "_links": {
+          "self": {
+            "href": "/discovery/v2/attractions/K8vZ9173I5f?locale=en-us"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "/discovery/v2/attractions.json?size=5&keyword=Group+love"
+    }
+  },
+  "page": {
+    "size": 5,
+    "totalElements": 3,
+    "totalPages": 1,
+    "number": 0
+  }
+}

--- a/data/keyword_event_search.json
+++ b/data/keyword_event_search.json
@@ -1,0 +1,368 @@
+// Results of event search with keywords 'music' and 'midtown'
+// Note that there may be multiple 'events' objects returned. It just so happened this result only returned 1
+{
+  "_embedded": {
+    "events": [
+      {
+        "name": "Music Midtown Festival",
+        "type": "event",
+        "id": "vvG1zZfiTcqnBz",
+        "test": false,
+        "url": "http://fgtix.to/musicmidtowntm",
+        "locale": "en-us",
+        "images": [
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_EVENT_DETAIL_PAGE_16_9.jpg",
+            "width": 205,
+            "height": 115,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_TABLET_LANDSCAPE_LARGE_16_9.jpg",
+            "width": 2048,
+            "height": 1152,
+            "fallback": false
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_RETINA_PORTRAIT_3_2.jpg",
+            "width": 640,
+            "height": 427,
+            "fallback": false
+          },
+          {
+            "ratio": "4_3",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_CUSTOM.jpg",
+            "width": 305,
+            "height": 225,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_RETINA_LANDSCAPE_16_9.jpg",
+            "width": 1136,
+            "height": 639,
+            "fallback": false
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_TABLET_LANDSCAPE_3_2.jpg",
+            "width": 1024,
+            "height": 683,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_RETINA_PORTRAIT_16_9.jpg",
+            "width": 640,
+            "height": 360,
+            "fallback": false
+          },
+          {
+            "ratio": "3_2",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_ARTIST_PAGE_3_2.jpg",
+            "width": 305,
+            "height": 203,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_RECOMENDATION_16_9.jpg",
+            "width": 100,
+            "height": 56,
+            "fallback": false
+          },
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_TABLET_LANDSCAPE_16_9.jpg",
+            "width": 1024,
+            "height": 576,
+            "fallback": false
+          }
+        ],
+        "sales": {
+          "public": {
+            "startDateTime": "2017-06-20T14:00:00Z",
+            "startTBD": false,
+            "endDateTime": "2017-09-16T16:00:00Z"
+          }
+        },
+        "dates": {
+          "start": {
+            "localDate": "2017-09-16",
+            "dateTBD": false,
+            "dateTBA": false,
+            "timeTBA": false,
+            "noSpecificTime": true
+          },
+          "end": {
+            "localDate": "2017-09-17",
+            "approximate": false,
+            "noSpecificTime": true
+          },
+          "timezone": "America/New_York",
+          "status": {
+            "code": "offsale"
+          },
+          "spanMultipleDays": false
+        },
+        "classifications": [
+          {
+            "primary": true,
+            "segment": {
+              "id": "KZFzniwnSyZfZ7v7nJ",
+              "name": "Music"
+            },
+            "genre": {
+              "id": "KnvZfZ7vAvl",
+              "name": "Other"
+            },
+            "subGenre": {
+              "id": "KZazBEonSMnZfZ7vk1I",
+              "name": "Other"
+            },
+            "type": {
+              "id": "KZAyXgnZfZ7v7nI",
+              "name": "Undefined"
+            },
+            "subType": {
+              "id": "KZFzBErXgnZfZ7v7lJ",
+              "name": "Undefined"
+            }
+          }
+        ],
+        "promoter": {
+          "id": "494",
+          "name": "PROMOTED BY VENUE",
+          "description": "PROMOTED BY VENUE / NTL / USA"
+        },
+        "promoters": [
+          {
+            "id": "494",
+            "name": "PROMOTED BY VENUE",
+            "description": "PROMOTED BY VENUE / NTL / USA"
+          }
+        ],
+        "_links": {
+          "self": {
+            "href": "/discovery/v2/events/vvG1zZfiTcqnBz?locale=en-us"
+          },
+          "attractions": [
+            {
+              "href": "/discovery/v2/attractions/K8vZ9171YvV?locale=en-us"
+            }
+          ],
+          "venues": [
+            {
+              "href": "/discovery/v2/venues/KovZpZAFl6dA?locale=en-us"
+            }
+          ]
+        },
+        "_embedded": {
+          "venues": [
+            {
+              "name": "PIEDMONT PARK",
+              "type": "venue",
+              "id": "KovZpZAFl6dA",
+              "test": false,
+              "url": "http://www.ticketmaster.com/venue/115455",
+              "locale": "en-us",
+              "postalCode": "30306",
+              "timezone": "America/New_York",
+              "city": {
+                "name": "Atlanta"
+              },
+              "state": {
+                "name": "Georgia",
+                "stateCode": "GA"
+              },
+              "country": {
+                "name": "United States Of America",
+                "countryCode": "US"
+              },
+              "address": {
+                "line1": "400 Park Drive"
+              },
+              "location": {
+                "longitude": "-84.3639749",
+                "latitude": "33.7842414"
+              },
+              "markets": [
+                {
+                  "id": "10"
+                }
+              ],
+              "dmas": [
+                {
+                  "id": 220
+                },
+                {
+                  "id": 221
+                },
+                {
+                  "id": 258
+                },
+                {
+                  "id": 327
+                },
+                {
+                  "id": 384
+                }
+              ],
+              "boxOfficeInfo": {
+                "phoneNumberDetail": "404.817.6634",
+                "openHoursDetail": "Day of event: 12:00pm",
+                "acceptedPaymentDetail": "Cash, Visa, MC, Discover, & American Express",
+                "willCallDetail": "Located: Park Entrance Open: 12:00pm"
+              },
+              "parkingDetail": "NO venue specific parking",
+              "accessibleSeatingDetail": "Piedmont Park is an \"all general admission\" venue. Patrons requesting accessible seating may purchase and use a regular general admission ticket. Please click \"Back\" to previous page and continue with standard purchase.",
+              "generalInfo": {
+                "generalRule": "Items NOT allowed: No pets, bags, backpacks, coolers, picnic baskets, water bottles, roller skates, roller blades, bikes, lawn chairs, umbrellas, cameras, video recorders, alcoholic beverages, festival poles, fireworks, drugs and weapons. Items Allowed: Blankets",
+                "childRule": "All ages!! Everyone needs a ticket to enter"
+              },
+              "upcomingEvents": {
+                "_total": 1,
+                "ticketmaster": 1
+              },
+              "_links": {
+                "self": {
+                  "href": "/discovery/v2/venues/KovZpZAFl6dA?locale=en-us"
+                }
+              }
+            }
+          ],
+          "attractions": [
+            {
+              "name": "Music Midtown Festival",
+              "type": "attraction",
+              "id": "K8vZ9171YvV",
+              "test": false,
+              "url": "http://www.ticketmaster.com/artist/861894",
+              "locale": "en-us",
+              "images": [
+                {
+                  "ratio": "16_9",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_EVENT_DETAIL_PAGE_16_9.jpg",
+                  "width": 205,
+                  "height": 115,
+                  "fallback": false
+                },
+                {
+                  "ratio": "16_9",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_TABLET_LANDSCAPE_LARGE_16_9.jpg",
+                  "width": 2048,
+                  "height": 1152,
+                  "fallback": false
+                },
+                {
+                  "ratio": "3_2",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_RETINA_PORTRAIT_3_2.jpg",
+                  "width": 640,
+                  "height": 427,
+                  "fallback": false
+                },
+                {
+                  "ratio": "4_3",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_CUSTOM.jpg",
+                  "width": 305,
+                  "height": 225,
+                  "fallback": false
+                },
+                {
+                  "ratio": "16_9",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_RETINA_LANDSCAPE_16_9.jpg",
+                  "width": 1136,
+                  "height": 639,
+                  "fallback": false
+                },
+                {
+                  "ratio": "3_2",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_TABLET_LANDSCAPE_3_2.jpg",
+                  "width": 1024,
+                  "height": 683,
+                  "fallback": false
+                },
+                {
+                  "ratio": "16_9",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_RETINA_PORTRAIT_16_9.jpg",
+                  "width": 640,
+                  "height": 360,
+                  "fallback": false
+                },
+                {
+                  "ratio": "3_2",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_ARTIST_PAGE_3_2.jpg",
+                  "width": 305,
+                  "height": 203,
+                  "fallback": false
+                },
+                {
+                  "ratio": "16_9",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_RECOMENDATION_16_9.jpg",
+                  "width": 100,
+                  "height": 56,
+                  "fallback": false
+                },
+                {
+                  "ratio": "16_9",
+                  "url": "https://s1.ticketm.net/dam/a/455/adea98a1-6581-432d-a340-fb2f5c6ca455_442381_TABLET_LANDSCAPE_16_9.jpg",
+                  "width": 1024,
+                  "height": 576,
+                  "fallback": false
+                }
+              ],
+              "classifications": [
+                {
+                  "primary": true,
+                  "segment": {
+                    "id": "KZFzniwnSyZfZ7v7nJ",
+                    "name": "Music"
+                  },
+                  "genre": {
+                    "id": "KnvZfZ7vAvl",
+                    "name": "Other"
+                  },
+                  "subGenre": {
+                    "id": "KZazBEonSMnZfZ7vk1I",
+                    "name": "Other"
+                  },
+                  "type": {
+                    "id": "KZAyXgnZfZ7v7nI",
+                    "name": "Undefined"
+                  },
+                  "subType": {
+                    "id": "KZFzBErXgnZfZ7v7lJ",
+                    "name": "Undefined"
+                  }
+                }
+              ],
+              "upcomingEvents": {
+                "_total": 1,
+                "ticketmaster": 1
+              },
+              "_links": {
+                "self": {
+                  "href": "/discovery/v2/attractions/K8vZ9171YvV?locale=en-us"
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "/discovery/v2/events.json?size=5&keyword=music%2Cmidtown"
+    }
+  },
+  "page": {
+    "size": 5,
+    "totalElements": 1,
+    "totalPages": 1,
+    "number": 0
+  }
+}

--- a/data/keyword_venue_search.json
+++ b/data/keyword_venue_search.json
@@ -1,0 +1,169 @@
+// results for a venue search with keywords "Philips" and "Arena"
+// again, the id is key here because we'll have to first display this list, then if the user wants to select a venue
+// to see events, we have to do an event search with that id supplied
+{
+  "_embedded": {
+    "venues": [
+      {
+        "name": "Philips Arena",
+        "type": "venue",
+        "id": "KovZpa2Xke",
+        "test": false,
+        "url": "http://www.ticketmaster.com/venue/114689",
+        "locale": "en-us",
+        "images": [
+          {
+            "ratio": "16_9",
+            "url": "https://s1.ticketm.net/dbimages/PhilipsArena2_GA_114689_4Z.gif",
+            "width": 205,
+            "height": 115,
+            "fallback": false
+          },
+          {
+            "ratio": "3_1",
+            "url": "https://s1.ticketm.net/dam/v/f39/93cc5796-5872-4355-b74d-a3fdc703ef39_378491_SOURCE.jpg",
+            "width": 1500,
+            "height": 500,
+            "fallback": false,
+            "attribution": "KovZpa2Xke"
+          }
+        ],
+        "postalCode": "30303",
+        "timezone": "America/New_York",
+        "city": {
+          "name": "Atlanta"
+        },
+        "state": {
+          "name": "Georgia",
+          "stateCode": "GA"
+        },
+        "country": {
+          "name": "United States Of America",
+          "countryCode": "US"
+        },
+        "address": {
+          "line1": "One Philips Drive"
+        },
+        "location": {
+          "longitude": "-84.394569",
+          "latitude": "33.757796"
+        },
+        "markets": [
+          {
+            "id": "10"
+          },
+          {
+            "id": "51"
+          }
+        ],
+        "dmas": [
+          {
+            "id": 200
+          },
+          {
+            "id": 220
+          },
+          {
+            "id": 221
+          },
+          {
+            "id": 258
+          },
+          {
+            "id": 327
+          },
+          {
+            "id": 384
+          }
+        ],
+        "social": {
+          "twitter": {
+            "handle": "@PhilipsArena"
+          }
+        },
+        "boxOfficeInfo": {
+          "phoneNumberDetail": "404-878-3000 - Philips Box Office 1-866-715-1500 - Atlanta Hawks",
+          "openHoursDetail": "The main box office is located on Centennial Olympic Park Drive. Open Monday-Friday; 9:30am-5:00pm.",
+          "acceptedPaymentDetail": "Accepts: cash, Visa, Mastercard, Discover, American Express",
+          "willCallDetail": "Located at main box office on Centennial Olympic Park Drive. Available for pickup beginning 1 1/2 hours prior to event. Closing time will vary by event. PLEASE BRING A PICTURE ID, THE ACTUAL CREDIT CARD USED TO PURCHASE THE TICKETS, AND YOUR ORDER NUMBER."
+        },
+        "parkingDetail": "Parking is available in various lots around Philips Arena including Centennial Garage and the CNN Deck located on Centennial Olympic Park Drive across from the arena. Both lots may be entered from Centennial Olympic Park Drive or Spring Street. Accessible parking is available in both lots. Price varies by event. The Philips Lot, located beneath the CNN Parking lot area, directly across from Philips Arena, is adjacent to “The Gulch” and can be entered from the downward ramp on Centennial Olympic Park Drive.",
+        "accessibleSeatingDetail": "Accessible seating is available in throughout the arena in various price categories. Seating for the sight/hearing impaired available in the lower level. All accessible seating is subject to availability. All levels of the Arena are accessible by elevator and escalator.",
+        "generalInfo": {
+          "generalRule": "No smoking inside arena (designated smoking areas will be provided outside the arena). No glass bottles , aluminum cans, coolers, thermoses, outside food, or alcoholic beverages No banners or laser pointers. No Backpacks.",
+          "childRule": "For most events, everyone two and older must have a ticket. For Sesame Street Live, children one and older must have a ticket. Please see the ticket information for each event."
+        },
+        "upcomingEvents": {
+          "_total": 13,
+          "tmr": 3,
+          "ticketmaster": 10
+        },
+        "_links": {
+          "self": {
+            "href": "/discovery/v2/venues/KovZpa2Xke?locale=en-us"
+          }
+        }
+      },
+      {
+        "name": "McGrath - Phillips Arena",
+        "type": "venue",
+        "id": "KovZpZAFdEeA",
+        "test": false,
+        "url": "http://www.ticketmaster.com/venue/32804",
+        "locale": "en-us",
+        "postalCode": "60614",
+        "timezone": "America/Chicago",
+        "city": {
+          "name": "Chicago"
+        },
+        "state": {
+          "name": "Illinois",
+          "stateCode": "IL"
+        },
+        "country": {
+          "name": "United States Of America",
+          "countryCode": "US"
+        },
+        "address": {
+          "line1": "2323 N. Sheffield Av."
+        },
+        "location": {
+          "longitude": "-87.653341",
+          "latitude": "41.923918"
+        },
+        "markets": [
+          {
+            "id": "3"
+          }
+        ],
+        "dmas": [
+          {
+            "id": 249
+          },
+          {
+            "id": 373
+          }
+        ],
+        "upcomingEvents": {
+          "_total": 0
+        },
+        "_links": {
+          "self": {
+            "href": "/discovery/v2/venues/KovZpZAFdEeA?locale=en-us"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "/discovery/v2/venues.json?keyword=Philips+Arena"
+    }
+  },
+  "page": {
+    "size": 20,
+    "totalElements": 2,
+    "totalPages": 1,
+    "number": 0
+  }
+}


### PR DESCRIPTION
The initial implementation of the API wrapper exposes three search methods:

- event search (the primary way of finding events)
- attraction search (used to find a specific artist or attraction)
- venue search (used to find a specific venue)

There is a long list of parameters than can be passed to event search to narrow the results, including an attraction or venue ID which can be obtained by their respective search. The full list of parameters can be found at the [API docs](http://developer.ticketmaster.com/products-and-docs/apis/discovery-api/v2/#search-events-v2).

I've also included some simple use cases of this modules methods at the bottom, as well as some sample result data that can be referenced when writing other modules that will parse the results.